### PR TITLE
Adjusts exceptions that are retried

### DIFF
--- a/src/main/kotlin/com/corgibytes/maven/MavenRepositoryImpl.kt
+++ b/src/main/kotlin/com/corgibytes/maven/MavenRepositoryImpl.kt
@@ -9,7 +9,8 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import nl.adaptivity.xmlutil.serialization.*
-import java.net.SocketException
+import java.io.IOException
+import java.nio.channels.UnresolvedAddressException
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
@@ -19,8 +20,8 @@ class MavenRepositoryImpl(repositoryUrl: String) : MavenRepository {
     private val client = HttpClient(CIO) {
         install(HttpRequestRetry) {
             retryOnServerErrors(maxRetries = 5)
-            retryOnExceptionIf { _, cause ->
-                cause is ConnectTimeoutException || cause is SocketException
+            retryOnExceptionIf(maxRetries = 5) { _, cause ->
+                cause is IOException || cause is UnresolvedAddressException
             }
             // a base delay of 1.35 will put the 5th delay at about 4.5 seconds (1.35 ** 5)
             exponentialDelay(base = 1.35)


### PR DESCRIPTION
Fixes #38.

* Sets `maxRetries`, because it looks like that value was only being set for server errors
* `IOException` is the ultimate parent of pretty much all of the exceptions that we need to issue a retry for
* `UnresolvedAddressException` happened once locally when I was running the tests while I switched from wifi to my hotspot