### PR TITLE
Fallbacks to dir listing if `metadata.xml` is not found

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation("io.github.pdvrieze.xmlutil:core-jvm:0.84.3")
     implementation("io.github.pdvrieze.xmlutil:serialization-jvm:0.84.3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
+    implementation("org.jsoup:jsoup:1.15.3")
 
     testImplementation("io.mockk:mockk:1.13.2")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-ktor_version=2.0.2
+ktor_version=2.1.2

--- a/src/main/kotlin/com/corgibytes/maven/MavenRepositoryImpl.kt
+++ b/src/main/kotlin/com/corgibytes/maven/MavenRepositoryImpl.kt
@@ -102,7 +102,7 @@ class MavenRepositoryImpl(repositoryUrl: String) : MavenRepository {
         }
     }
 
-    fun getVersionsFromDirectoryListing(groupId: String, artifactId: String): List<String> {
+    private fun getVersionsFromDirectoryListing(groupId: String, artifactId: String): List<String> {
         val wasRequestSuccessful: Boolean
         val responseBody: String
         runBlocking {
@@ -123,7 +123,7 @@ class MavenRepositoryImpl(repositoryUrl: String) : MavenRepository {
         val links = document.select("a")
         var results = emptyList<String>()
         links.forEach {
-            val target = it.attr("href")
+            val target = it.attr("href").removeSuffix("/")
             if (target != "..") {
                 if (isVersionNumberFor(groupId, artifactId, target)) {
                     results = results.plus(target)
@@ -152,7 +152,7 @@ class MavenRepositoryImpl(repositoryUrl: String) : MavenRepository {
     private fun doesContainVersionFor(groupId: String, artifactId: String, target: String, responseBody: String): Boolean {
         val document = Jsoup.parse(responseBody)
         val links = document.select("a")
-        return links.map { it.attr("href") }.contains("$artifactId-$target.pom")
+        return links.map { it.attr("href").removeSuffix("/") }.contains("$artifactId-$target.pom")
     }
 
     fun buildDirectoryListingUrl(groupId: String, artifactId: String, target: String? = null): String {

--- a/src/main/kotlin/com/corgibytes/maven/MavenRepositoryImpl.kt
+++ b/src/main/kotlin/com/corgibytes/maven/MavenRepositoryImpl.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import nl.adaptivity.xmlutil.serialization.*
+import org.jsoup.Jsoup
 import java.io.IOException
 import java.nio.channels.UnresolvedAddressException
 import java.time.ZonedDateTime
@@ -97,7 +98,69 @@ class MavenRepositoryImpl(repositoryUrl: String) : MavenRepository {
         return if (wasRequestSuccessful) {
             parseVersionsFromMetadataResponse(responseBody)
         } else {
+            getVersionsFromDirectoryListing(groupId, artifactId)
+        }
+    }
+
+    fun getVersionsFromDirectoryListing(groupId: String, artifactId: String): List<String> {
+        val wasRequestSuccessful: Boolean
+        val responseBody: String
+        runBlocking {
+            val response = client.get(buildDirectoryListingUrl(groupId, artifactId))
+            wasRequestSuccessful = response.status.value < 400
+            responseBody = response.body()
+        }
+
+        return if (wasRequestSuccessful) {
+            parseVersionsFromDirectoryListingResponse(groupId, artifactId, responseBody)
+        } else {
             emptyList()
+        }
+    }
+
+    private fun parseVersionsFromDirectoryListingResponse(groupId: String, artifactId: String, responseBody: String): List<String> {
+        val document = Jsoup.parse(responseBody)
+        val links = document.select("a")
+        var results = emptyList<String>()
+        links.forEach {
+            val target = it.attr("href")
+            if (target != "..") {
+                if (isVersionNumberFor(groupId, artifactId, target)) {
+                    results = results.plus(target)
+                }
+            }
+        }
+        return results
+    }
+
+    private fun isVersionNumberFor(groupId: String, artifactId: String, target: String): Boolean {
+        val wasRequestSuccessful: Boolean
+        val responseBody: String
+        runBlocking {
+            val response = client.get(buildDirectoryListingUrl(groupId, artifactId, target))
+            wasRequestSuccessful = response.status.value < 400
+            responseBody = response.body()
+        }
+
+        return if (wasRequestSuccessful) {
+            doesContainVersionFor(groupId, artifactId, target, responseBody)
+        } else {
+            false
+        }
+    }
+
+    private fun doesContainVersionFor(groupId: String, artifactId: String, target: String, responseBody: String): Boolean {
+        val document = Jsoup.parse(responseBody)
+        val links = document.select("a")
+        return links.map { it.attr("href") }.contains("$artifactId-$target.pom")
+    }
+
+    fun buildDirectoryListingUrl(groupId: String, artifactId: String, target: String? = null): String {
+        val artifactListingUrl = "$repositoryUrl/${groupId.replace(".", "/")}/$artifactId"
+        return if (target == null) {
+            artifactListingUrl
+        } else {
+            "$artifactListingUrl/$target"
         }
     }
 

--- a/src/test/kotlin/com/corgibytes/maven/ReleaseHistoryServiceTest.kt
+++ b/src/test/kotlin/com/corgibytes/maven/ReleaseHistoryServiceTest.kt
@@ -91,6 +91,22 @@ class ReleaseHistoryServiceTest {
     }
 
     @Test
+    fun retrieveReleaseHistoryForJcipAnnotations() {
+        val service = ReleaseHistoryService()
+
+        val actualResults = service.getVersionHistory("net.jcip", "jcip-annotations")
+
+        val expectedResults = mapOf(
+            "1.0" to "Thu, 14 Aug 2008 01:48:00 GMT",
+        )
+
+        expectedResults.forEach { version, rawExpectedDateTime ->
+            val expectedDateTime = ZonedDateTime.parse(rawExpectedDateTime, DateTimeFormatter.RFC_1123_DATE_TIME)
+            assertEquals(expectedDateTime, actualResults.get(version))
+        }
+    }
+
+    @Test
     fun retrieveReleaseHistoryFromAlternativeLocation() {
         val service = ReleaseHistoryService("http://repo.spring.io/release")
 

--- a/src/test/kotlin/com/corgibytes/maven/ReleaseHistoryServiceTest.kt
+++ b/src/test/kotlin/com/corgibytes/maven/ReleaseHistoryServiceTest.kt
@@ -97,7 +97,7 @@ class ReleaseHistoryServiceTest {
         val actualResults = service.getVersionHistory("net.jcip", "jcip-annotations")
 
         val expectedResults = mapOf(
-            "1.0" to "Thu, 14 Aug 2008 01:48:00 GMT",
+            "1.0" to "Thu, 14 Aug 2008 06:48:05 GMT",
         )
 
         expectedResults.forEach { version, rawExpectedDateTime ->


### PR DESCRIPTION
Some modules, such as `net.jcip/jcip-annotations`, do not have a published `metadata.xml` file. This change attempts to fallback to parsing a directory listing of the specified package in cases where a `metadata.xml` file cannot be found.

Fixes #40.