### PR TITLE
Handle missing pom files

### DIFF
--- a/src/main/kotlin/com/corgibytes/maven/LastModifiedHeaderNotFound.kt
+++ b/src/main/kotlin/com/corgibytes/maven/LastModifiedHeaderNotFound.kt
@@ -1,0 +1,4 @@
+package com.corgibytes.maven
+
+class LastModifiedHeaderNotFound(url: String): Exception("Last-Modified header is not present for $url") {
+}

--- a/src/main/kotlin/com/corgibytes/maven/PomFileNotFoundException.kt
+++ b/src/main/kotlin/com/corgibytes/maven/PomFileNotFoundException.kt
@@ -1,0 +1,4 @@
+package com.corgibytes.maven
+
+class PomFileNotFoundException(url: String) : Exception("Unable to retrieve $url") {
+}

--- a/src/test/kotlin/com/corgibytes/maven/MavenRepositoryImplTest.kt
+++ b/src/test/kotlin/com/corgibytes/maven/MavenRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import java.time.format.DateTimeFormatter
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 
 class MavenRepositoryImplTest {
@@ -109,6 +110,17 @@ class MavenRepositoryImplTest {
                 expectedDateTime,
                 repository.getVersionReleaseDate("org.apache.maven", "apache-maven", "2.0.10")
             )
+        }
+    }
+
+    @Test
+    fun getVersionReleaseDateNotFound() {
+        val repository = MavenRepositoryImpl(MavenRepositoryImpl.mavenCentralUrl)
+
+        assertFailsWith<PomFileNotFoundException> {
+            runBlocking {
+                repository.getVersionReleaseDate("org.example", "fake-package", "2.1.3")
+            }
         }
     }
 


### PR DESCRIPTION
A missing pom file was causing CI to fail. This fixes the problem by ignoring the corresponding version that was associated with the missing pom file.